### PR TITLE
Push Inner/Outer content to their own repo

### DIFF
--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -29,8 +29,8 @@
 
 * xref:11-openshift.adoc[OpenShift for Developers]
 
-* xref:12-openshift-inner-outer-loop.adoc[OpenShift Inner & Outer Loops]
-** xref:12-openshift-inner-outer-loop.adoc#one[OpenShift Inner Loop]
-** xref:12-openshift-inner-outer-loop.adoc#two[OpenShift Outer Loop]
+* OpenShift Inner & Outer Loop Workshops
+** link:https://redhat-scholars.github.io/inner-loop-guide/[OpenShift Inner Loop]
+** link:https://redhat-scholars.github.io/outer-loop-guide/[OpenShift Outer Loop]
 
-* xref:13-openshift-java-inner-loop.adoc[OpenShift Java Inner Loop]
+* xref:13-openshift-java-inner-loop.adoc[OpenShift Java Inner Loop Workshop]

--- a/documentation/modules/ROOT/pages/index.adoc
+++ b/documentation/modules/ROOT/pages/index.adoc
@@ -66,10 +66,10 @@
 * xref:11-openshift.adoc[OpenShift for Developers]
 
 [.tile]
-.xref:12-openshift-inner-outer-loop.adoc[OpenShift Inner & Outer Loops]
-* xref:12-openshift-inner-outer-loop.adoc#one[OpenShift Inner Loop]
-* xref:12-openshift-inner-outer-loop.adoc#two[OpenShift Outer Loop]
+.OpenShift Inner & Outer Loop Workshops
+* link:https://redhat-scholars.github.io/inner-loop-guide/[OpenShift Inner Loop,window=_blank]
+* link:https://redhat-scholars.github.io/outer-loop-guide/[OpenShift Outer Loop,window=_blank]
 
 [.tile]
-.xref:13-openshift-java-inner-loop.adoc[OpenShift Java Inner Loop]
+.xref:13-openshift-java-inner-loop.adoc[OpenShift Java Inner Loop Workshop]
 * xref:13-openshift-java-inner-loop.adoc[OpenShift Java Inner Loop]


### PR DESCRIPTION
Here is my plan to push the descriptions in the index back down into the repo that owns the content, making it much easier to maintain (in one place). I have converted the doc references to links and then moved the summary content into the inner and outer repo. I have used the /index.html page, but you could easily create a new /summary.html page to serve the content you have created. My suggestion would be to repeat this task for all the other content sections making the top level index VERY lightweight with barely any content at all.